### PR TITLE
Enable support for the Scala3/Native combo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ bin/
 *.ipr
 *.iws
 .bsp/
+.metals
+.vscode

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -16,7 +16,6 @@ spaces.inImportCurlyBraces = true
 # https://docs.scala-lang.org/style/indentation.html#methods-with-numerous-arguments
 align.openParenCallSite = false
 align.openParenDefnSite = false
-align.preset = more
 
 danglingParentheses.defnSite = true
 danglingParentheses.callSite = true

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,5 @@
-version = "2.7.5"
+version = "3.1.2"
+runner.dialect = scala213
 preset=default
 maxColumn = 120
 project.git = true
@@ -6,7 +7,7 @@ lineEndings = preserve
 
 # https://docs.scala-lang.org/style/scaladoc.html recommends the JavaDoc style.
 # scala/scala is written that way too https://github.com/scala/scala/blob/v2.12.2/src/library/scala/Predef.scala
-docstrings = JavaDoc
+docstrings.style = Asterisk
 
 # This also seems more idiomatic to include whitespace in import x.{ yyy }
 spaces.inImportCurlyBraces = true
@@ -15,8 +16,15 @@ spaces.inImportCurlyBraces = true
 # https://docs.scala-lang.org/style/indentation.html#methods-with-numerous-arguments
 align.openParenCallSite = false
 align.openParenDefnSite = false
+align.preset = more
 
 danglingParentheses.defnSite = true
 danglingParentheses.callSite = true
 
 trailingCommas = preserve
+
+fileOverride {
+  "glob:**/scala-3/**.scala" {
+    runner.dialect = scala3
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -28,10 +28,6 @@ lazy val expecty = (projectMatrix in file("."))
   .settings(
     name := "Expecty",
     scalacOptions ++= Seq("-Yrangepos", "-feature", "-deprecation"),
-    scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((3, _)) => Seq("-scala-output-version", "3.1")
-      case _            => Nil
-    }),
     libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, _)) => Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
       case _            => Nil

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,8 @@
 val scala211 = "2.11.12"
 val scala212 = "2.12.15"
 val scala213 = "2.13.8"
-val scala3 = "3.0.2"
+val scala3 = "3.1.2"
+val scalaFull = Seq(scala213, scala212, scala211, scala3)
 ThisBuild / scalaVersion := scala213
 Global / semanticdbEnabled := true
 Global / semanticdbVersion := "4.5.0"
@@ -27,6 +28,10 @@ lazy val expecty = (projectMatrix in file("."))
   .settings(
     name := "Expecty",
     scalacOptions ++= Seq("-Yrangepos", "-feature", "-deprecation"),
+    scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((3, _)) => Seq("-scala-output-version", "3.1")
+      case _            => Nil
+    }),
     libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, _)) => Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
       case _            => Nil
@@ -35,7 +40,7 @@ lazy val expecty = (projectMatrix in file("."))
     testFrameworks += new TestFramework("verify.runner.Framework"),
   )
   .jvmPlatform(
-    scalaVersions = Seq(scala213, scala212, scala211, scala3),
+    scalaVersions = scalaFull,
     settings = Seq(
       libraryDependencies += "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
       Test / unmanagedSourceDirectories ++= {
@@ -43,8 +48,8 @@ lazy val expecty = (projectMatrix in file("."))
       },
     )
   )
-  .jsPlatform(scalaVersions = Seq(scala213, scala212, scala211, scala3))
-  .nativePlatform(scalaVersions = Seq(scala211, scala212, scala213))
+  .jsPlatform(scalaVersions = scalaFull)
+  .nativePlatform(scalaVersions = scalaFull)
 
 lazy val expecty3 = expecty
   .jvm(scala3)

--- a/jvm/src/test/scala/org/expecty/ExpectySpec.scala
+++ b/jvm/src/test/scala/org/expecty/ExpectySpec.scala
@@ -61,7 +61,7 @@ class ExpectySpec {
     )
   }
 
-  //TODO: needs assertion
+  // TODO: needs assertion
   // @Test(expected = classOf[AssertionError])
   // def lateFailingExpectation(): Unit = {
   //   def expect = new Expecty(failEarly = false)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 val scalaJSVersion =
   Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.10.1")
 val scalaNativeVersion =
-  Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.4.4")
+  Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.4.7")
 
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
 addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.9.0")

--- a/src/main/scala-2/com/eed3si9n/expecty/RecorderMacro.scala
+++ b/src/main/scala-2/com/eed3si9n/expecty/RecorderMacro.scala
@@ -144,8 +144,8 @@ Instrumented AST: ${showRaw(instrumented)}")
       case Literal(_) => expr // don't record
       // don't record value of implicit "this" added by compiler; couldn't find a better way to detect implicit "this" than via point
       case Select(x @ This(_), y) if getPosition(expr).point == getPosition(x).point => expr
-      case x: Select if x.symbol.isModule                                            => expr // don't try to record the value of packages
-      case Apply(_, _) if expr.symbol.isImplicit                                     => recordSubValues(expr)
+      case x: Select if x.symbol.isModule        => expr // don't try to record the value of packages
+      case Apply(_, _) if expr.symbol.isImplicit => recordSubValues(expr)
       case _ =>
         val sub = recordSubValues(expr)
         val res = recordValue(sub, expr)

--- a/src/main/scala-3/com/eed3si9n/expecty/AssertEqualsMacro.scala
+++ b/src/main/scala-3/com/eed3si9n/expecty/AssertEqualsMacro.scala
@@ -1,23 +1,23 @@
 /*
-* Copyright 2021 the original author or authors.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*     http://www.apache.org/licenses/LICENSE-2.0
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.eed3si9n.expecty
 
 trait AssertEquals[R] {
   def stringAssertEqualsListener: RecorderListener[String, R]
-  inline def assertEquals(expected: String, found: String): R = 
+  inline def assertEquals(expected: String, found: String): R =
     ${ StringRecorderMacro.apply('expected, 'found, 'stringAssertEqualsListener) }
-  inline def assertEquals(expected: String, found: String, message: => String): R = 
+  inline def assertEquals(expected: String, found: String, message: => String): R =
     ${ StringRecorderMacro.apply('expected, 'found, 'message, 'stringAssertEqualsListener) }
 }

--- a/src/main/scala-3/com/eed3si9n/expecty/Recorder.scala
+++ b/src/main/scala-3/com/eed3si9n/expecty/Recorder.scala
@@ -1,16 +1,16 @@
 /*
-* Copyright 2012 the original author or authors.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*     http://www.apache.org/licenses/LICENSE-2.0
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.eed3si9n.expecty
 
 import language.experimental.macros

--- a/src/main/scala/com/eed3si9n/expecty/DiffUtil.scala
+++ b/src/main/scala/com/eed3si9n/expecty/DiffUtil.scala
@@ -72,13 +72,15 @@ object DiffUtil {
   }
 
   /**
-   * Return a colored diff between the tokens of every line in `expected` and `actual`. Each line of
-   * output contains the expected value on the left and the actual value on the right.
+   * Return a colored diff between the tokens of every line in `expected` and `actual`. Each line of output contains the
+   * expected value on the left and the actual value on the right.
    *
-   * @param expected The expected lines
-   * @param actual   The actual lines
-   * @return A string with one element of `expected` and `actual` on each lines, where
-   *         differences are highlighted.
+   * @param expected
+   *   The expected lines
+   * @param actual
+   *   The actual lines
+   * @return
+   *   A string with one element of `expected` and `actual` on each lines, where differences are highlighted.
    */
   def mkColoredLineDiff(expected: Seq[String], actual: Seq[String]): String = {
     val diffs =

--- a/src/test/scala-3/ExpectyScala3Test.scala
+++ b/src/test/scala-3/ExpectyScala3Test.scala
@@ -22,25 +22,23 @@ object ExpectyScala3Test extends verify.BasicTestSuite {
 
   val name = "Hi from Expecty!"
 
-   trait Eq[T]:
-     def eq(x: T, y: T): Boolean
+  trait Eq[T]:
+    def eq(x: T, y: T): Boolean
 
-   object Eq:
-     given Eq[Int] with
-       def eq(x: Int, y: Int) = (x - y) == 0
+  object Eq:
+    given Eq[Int] with
+      def eq(x: Int, y: Int) = (x - y) == 0
 
   test("scala 3 extension (1)") {
     // Regression test for https://github.com/eed3si9n/expecty/issues/50
-    extension [T](i: T)(using eq: Eq[T])
-      def ===(other: T) = eq.eq(i, other)
+    extension [T](i: T)(using eq: Eq[T]) def ===(other: T) = eq.eq(i, other)
 
     assert1("abc".length() === 3)
   }
 
   test("scala 3 extension (2)") {
     // Regression test for https://github.com/eed3si9n/expecty/issues/50
-    extension [T](i: T)
-      def ===(other: T)(using eq: Eq[T]) = eq.eq(i, other)
+    extension [T](i: T) def ===(other: T)(using eq: Eq[T]) = eq.eq(i, other)
 
     assert1("abc".length() === 3)
   }
@@ -69,4 +67,3 @@ object ExpectyScala3Test extends verify.BasicTestSuite {
     assert1(cats.data.Chain(1, 2, 3).size == 3)
   }
 }
-

--- a/src/test/scala-3/Fixtures.scala
+++ b/src/test/scala-3/Fixtures.scala
@@ -1,7 +1,7 @@
 package cats {
   package data {
     object Chain {
-      def apply[A](a: A*) : List[A] = List(a*)
+      def apply[A](a: A*): List[A] = List(a*)
     }
   }
 }


### PR DESCRIPTION
This bumps Scala 3 to 3.2, but fixes emitted version to 3.1.